### PR TITLE
fix defaults

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ module.exports = function (rules, options, callback){
   // -----------------------------
   // --- Default Option Values ---
   // -----------------------------
-  options = _.defaults(options, config, {
+  options = _.defaults({}, options, config, {
     responseMethod: res.badRequest,
     sendResponse: true,
     usePromise: false,


### PR DESCRIPTION
In case `.validate()` method calling without options, following error throws:
```
TypeError: Cannot read property 'returnAllParams' of undefined
    at returnData (sails-hook-req-validate/lib/index.js:67:17)
```
That's because calling `_.defaults(null, {} ,{})` return `null` with lodash v3.x.

I propose this fix as:
- sails team use their own fork of @sailshq/lodash and there v3.x
- all versions of lodash method `_.defaults()` mutates source object