### PR TITLE
Allow custom validator to return an error string

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -20,8 +20,12 @@ module.exports = function(options, key, validations, param) {
   else if (_.isFunction(validations)) {
      try {
        const test = validations(param);
-       if (!_.isBoolean(test)) {
-         return { error: 'The validation response must be boolean.' };
+       // If the custom test returns a string, use that as the error message
+       if (_.isString(test)) {
+         return { error: test };
+       }
+       else if (!_.isBoolean(test)) {
+         return { error: 'The validation response must be boolean or an error message.' };
        }
        return test ? { value: param } : { error: 'The validation failed' };
      } catch (e) {


### PR DESCRIPTION
Example:

This custom validator allows checking if a `password` field and `password_confirmation` field have the same value.

```
req.validate({
    password: (val) => (val === req.param('password_confirm') ? true : 'password and confirmation must match'),
});
```